### PR TITLE
fix: resolve SymPy AttributeError and missing math import

### DIFF
--- a/sympybotics/robotmodel.py
+++ b/sympybotics/robotmodel.py
@@ -1,12 +1,14 @@
 
 import sys
 import numpy
+import math
 
 from .geometry import Geometry
 from .kinematics import Kinematics
 from .dynamics import Dynamics
 from .symcode import Subexprs, code_to_func
 from ._compatibility_ import exec_
+
 
 def _fprint(x):
     print(x)
@@ -40,7 +42,7 @@ class RobotDynCode(object):
         if verbose:
             p = _fprint
         else:
-            p = lambda x: None
+            def p(x): return None
 
         self.rbtdef = rbtdef
         self.dof = rbtdef.dof

--- a/sympybotics/symcode/subexprs.py
+++ b/sympybotics/symcode/subexprs.py
@@ -139,7 +139,7 @@ class Subexprs(object):
             # Exclude atoms, since there is no point in renaming them.
             return expr
 
-        if sympy.iterables.iterable(expr):
+        if sympy.utilities.iterables.iterable(expr):
             return expr
 
         subexpr = type(expr)(*map(self._parse, expr.args))


### PR DESCRIPTION
This PR fixes two issues:

1. AttributeError for 'iterables' in SymPy
Fixed the error module 'sympy' has no attribute 'iterables' by correcting the usage of SymPy's iterables module.

2. NameError for undefined 'math'
Added the missing import math to resolve the NameError: name 'math' is not defined issue.

These changes ensure proper module imports and prevent runtime errors.